### PR TITLE
chore: remove unnecessary semicolon

### DIFF
--- a/client/packages/openblocks/src/pages/common/header.tsx
+++ b/client/packages/openblocks/src/pages/common/header.tsx
@@ -483,7 +483,7 @@ export function AppHeader() {
           </StyledLink>
         </div>
       )}
-      <HeaderProfile user={user} />;
+      <HeaderProfile user={user} />
     </>
   );
   return (


### PR DESCRIPTION
Remove unecessary semicolon that was being rendered next to the user's avatar in the header.

Before:
![image](https://github.com/user-attachments/assets/0b2a8b38-4ccb-4798-87eb-5c54ff509195)

After:
![image](https://github.com/user-attachments/assets/c6363892-706f-43fc-b63a-4c4102665004)
